### PR TITLE
Smoke-test the packaged VSIX before releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,9 +92,68 @@ jobs:
           path: "*.vsix"
           if-no-files-found: error
 
+  smoke:
+    name: Smoke test the VSIX
+    # Runs on a fresh runner with only smoke/ checked out (sparse, cone
+    # mode — root-level files come along, src/ and out/ do not), so the
+    # only copy of the extension that can be found is the artifact. The
+    # negative control proves the same assertions fail when the VSIX is
+    # not installed; without it a green smoke run says nothing.
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: smoke
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: smoke
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: smoke/pnpm-lock.yaml
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vsix
+          path: artifacts
+
+      - name: Structural check
+        run: |
+          set -euo pipefail
+          vsix="$(ls "$GITHUB_WORKSPACE"/artifacts/*.vsix)"
+          unzip -q "$vsix" -d "$RUNNER_TEMP/vsix-contents"
+          node inspect-vsix.js "$RUNNER_TEMP/vsix-contents" "${GITHUB_REF_NAME#v}"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Negative control (must fail without the VSIX)
+        run: |
+          set +e
+          xvfb-run -a node run.js --expect-version "${GITHUB_REF_NAME#v}"
+          rc=$?
+          set -e
+          if [ "$rc" -ne 1 ]; then
+            echo "::error::expected the smoke test to fail with exit 1 when no VSIX is installed, got $rc"
+            exit 1
+          fi
+
+      - name: Activation smoke
+        run: |
+          set -euo pipefail
+          vsix="$(ls "$GITHUB_WORKSPACE"/artifacts/*.vsix)"
+          xvfb-run -a node run.js --vsix "$vsix" --expect-version "${GITHUB_REF_NAME#v}"
+
   release:
     name: Create Release
-    needs: build
+    needs: smoke
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,3 +8,8 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+.github/**
+out/test/**
+out/generater/**
+pnpm-workspace.yaml
+smoke/**

--- a/smoke/.gitignore
+++ b/smoke/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.vscode-test

--- a/smoke/host-extension/extension.js
+++ b/smoke/host-extension/extension.js
@@ -1,0 +1,2 @@
+exports.activate = () => {};
+exports.deactivate = () => {};

--- a/smoke/host-extension/package.json
+++ b/smoke/host-extension/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "line-number-deco-smoke-host",
+  "displayName": "line-number-deco smoke host",
+  "publisher": "ShortArrow",
+  "version": "0.0.0",
+  "private": true,
+  "engines": {
+    "vscode": "^1.76.0"
+  },
+  "main": "./extension.js",
+  "activationEvents": []
+}

--- a/smoke/host-extension/suite/index.js
+++ b/smoke/host-extension/suite/index.js
@@ -1,0 +1,95 @@
+const fs = require('fs');
+const path = require('path');
+const vscode = require('vscode');
+
+const EXTENSION_ID = 'ShortArrow.line-number-deco';
+
+const EXPECTED_COMMANDS = [
+  'line-number-deco.enableRainbow',
+  'line-number-deco.disableRainbow',
+  'line-number-deco.enableRainbowForUser',
+  'line-number-deco.disableRainbowForUser'
+];
+
+/**
+ * Reads a required environment variable.
+ * @throws {Error} when the variable is unset or empty.
+ */
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`missing required environment variable ${name}`);
+  }
+  return value;
+}
+
+/** Collects the failures of C2-C5, which only make sense once the extension is present. */
+async function checkInstalledExtension(ext, expectVersion, extensionsDir) {
+  const failures = [];
+
+  const actualPath = fs.realpathSync(ext.extensionPath);
+  const expectedPrefix = fs.realpathSync(extensionsDir) + path.sep;
+  if (!actualPath.startsWith(expectedPrefix)) {
+    failures.push(
+      `extension was loaded from ${actualPath}, which is not inside the smoke extensions dir ${expectedPrefix}`
+    );
+  }
+
+  const actualVersion = ext.packageJSON.version;
+  if (actualVersion !== expectVersion) {
+    failures.push(`extension version is ${actualVersion}, expected ${expectVersion}`);
+  }
+
+  try {
+    await ext.activate();
+  } catch (error) {
+    failures.push(`activate() rejected: ${error && error.stack ? error.stack : error}`);
+  }
+  if (!ext.isActive) {
+    failures.push('extension is not active after activate() resolved');
+  }
+
+  const commands = await vscode.commands.getCommands(true);
+  const missing = EXPECTED_COMMANDS.filter((command) => !commands.includes(command));
+  if (missing.length > 0) {
+    failures.push(`commands not registered: ${missing.join(', ')}`);
+  }
+
+  return failures;
+}
+
+/** Writes the result file the driver reads, creating its parent directory. */
+function writeResult(resultFile, failures) {
+  fs.mkdirSync(path.dirname(resultFile), { recursive: true });
+  fs.writeFileSync(
+    resultFile,
+    JSON.stringify({ ok: failures.length === 0, failures }, null, 2)
+  );
+}
+
+/**
+ * Asserts that the VSIX under test is the extension VS Code loaded, at the
+ * expected version, and that it activates with its commands registered.
+ * @returns {Promise<void>} resolves when every check passed.
+ */
+async function run() {
+  const expectVersion = requireEnv('SMOKE_EXPECT_VERSION');
+  const extensionsDir = requireEnv('SMOKE_EXTENSIONS_DIR');
+  const resultFile = requireEnv('SMOKE_RESULT_FILE');
+
+  let failures;
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  if (!ext) {
+    failures = [`extension ${EXTENSION_ID} is not installed`];
+  } else {
+    failures = await checkInstalledExtension(ext, expectVersion, extensionsDir);
+  }
+
+  writeResult(resultFile, failures);
+
+  if (failures.length > 0) {
+    throw new Error(failures.join('\n'));
+  }
+}
+
+exports.run = run;

--- a/smoke/inspect-vsix.js
+++ b/smoke/inspect-vsix.js
@@ -1,0 +1,149 @@
+const fs = require('fs');
+const path = require('path');
+
+const USAGE = 'usage: node inspect-vsix.js <unzipped-dir> <expected-version>';
+
+const FORBIDDEN_PREFIXES = [
+  'src/',
+  'out/test/',
+  'out/generater/',
+  'smoke/',
+  '.github/',
+  'node_modules/'
+];
+
+const FORBIDDEN_FILES = ['pnpm-lock.yaml', 'pnpm-workspace.yaml', 'yarn.lock'];
+
+/** @returns {string[]} every file path under dir, relative to it, with forward slashes. */
+function walk(dir, prefix = '') {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      files.push(...walk(path.join(dir, entry.name), relative));
+    } else {
+      files.push(relative);
+    }
+  }
+  return files;
+}
+
+function isFile(candidate) {
+  return fs.existsSync(candidate) && fs.statSync(candidate).isFile();
+}
+
+/** I1: the VSIX envelope survived the unzip. */
+function checkEnvelope(dir, failures) {
+  for (const name of ['extension.vsixmanifest', '[Content_Types].xml']) {
+    if (!isFile(path.join(dir, name))) {
+      failures.push(`missing ${name}`);
+    }
+  }
+}
+
+/** I2: the manifest identifies the extension under test at the expected version. */
+function readManifest(extensionDir, expectedVersion, failures) {
+  const manifestPath = path.join(extensionDir, 'package.json');
+  if (!isFile(manifestPath)) {
+    failures.push('missing extension/package.json');
+    return undefined;
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch (error) {
+    failures.push(`extension/package.json is not valid JSON: ${error.message}`);
+    return undefined;
+  }
+
+  if (manifest.version !== expectedVersion) {
+    failures.push(`version is ${manifest.version}, expected ${expectedVersion}`);
+  }
+  if (manifest.name !== 'line-number-deco') {
+    failures.push(`name is ${manifest.name}, expected line-number-deco`);
+  }
+  if (manifest.publisher !== 'ShortArrow') {
+    failures.push(`publisher is ${manifest.publisher}, expected ShortArrow`);
+  }
+  return manifest;
+}
+
+/** I3: the entry point named by the manifest is really shipped and has content. */
+function checkMain(extensionDir, manifest, failures) {
+  if (!manifest || !manifest.main) {
+    failures.push('extension/package.json has no main');
+    return;
+  }
+  const mainPath = path.join(extensionDir, manifest.main);
+  if (!isFile(mainPath)) {
+    failures.push(`main ${manifest.main} does not exist`);
+    return;
+  }
+  if (fs.statSync(mainPath).size === 0) {
+    failures.push(`main ${manifest.main} is empty`);
+  }
+}
+
+/** I4: nothing that belongs to development leaked into the package. */
+function checkNoDevelopmentFiles(files, failures) {
+  for (const file of files) {
+    const prefix = FORBIDDEN_PREFIXES.find((candidate) => file.startsWith(candidate));
+    if (prefix) {
+      failures.push(`packaged file ${file} is under ${prefix}`);
+    }
+    if (FORBIDDEN_FILES.includes(file)) {
+      failures.push(`packaged file ${file} should not ship`);
+    }
+  }
+}
+
+/** I5: the generated table extension.js imports at runtime is present. */
+function checkGenerated(extensionDir, failures) {
+  if (!isFile(path.join(extensionDir, 'out', 'generated', 'generated.js'))) {
+    failures.push('missing out/generated/generated.js');
+  }
+}
+
+function main(argv) {
+  const [dir, expectedVersion] = argv;
+  if (!dir || !expectedVersion) {
+    console.error(USAGE);
+    return 2;
+  }
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    console.error(`inspect FAIL: ${dir} is not a directory`);
+    return 1;
+  }
+
+  const failures = [];
+  const extensionDir = path.join(dir, 'extension');
+
+  checkEnvelope(dir, failures);
+
+  if (!fs.existsSync(extensionDir)) {
+    failures.push('missing extension/ directory');
+    for (const failure of failures) {
+      console.error(`inspect FAIL: ${failure}`);
+    }
+    return 1;
+  }
+
+  const manifest = readManifest(extensionDir, expectedVersion, failures);
+  checkMain(extensionDir, manifest, failures);
+
+  const files = walk(extensionDir);
+  checkNoDevelopmentFiles(files, failures);
+  checkGenerated(extensionDir, failures);
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(`inspect FAIL: ${failure}`);
+    }
+    return 1;
+  }
+  console.log(`inspect OK (${files.length} files)`);
+  return 0;
+}
+
+process.exitCode = main(process.argv.slice(2));

--- a/smoke/package.json
+++ b/smoke/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "line-number-deco-smoke",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Installs a packaged VSIX of line-number-deco into a fresh VS Code profile and asserts it activates",
+  "packageManager": "pnpm@11.22.0",
+  "scripts": {
+    "inspect": "node inspect-vsix.js",
+    "smoke": "node run.js"
+  },
+  "devDependencies": {
+    "@vscode/test-electron": "^2.5.2"
+  }
+}

--- a/smoke/pnpm-lock.yaml
+++ b/smoke/pnpm-lock.yaml
@@ -1,0 +1,299 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@vscode/test-electron':
+        specifier: ^2.5.2
+        version: 2.5.2
+
+packages:
+
+  '@vscode/test-electron@2.5.2':
+    resolution: {integrity: sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==}
+    engines: {node: '>=16'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+snapshots:
+
+  '@vscode/test-electron@2.5.2':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      jszip: 3.10.1
+      ora: 8.2.0
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - supports-color
+
+  agent-base@7.1.4: {}
+
+  ansi-regex@6.3.0: {}
+
+  chalk@5.6.2: {}
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
+
+  core-util-is@1.0.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  emoji-regex@10.6.0: {}
+
+  get-east-asian-width@1.6.0: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  immediate@3.0.6: {}
+
+  inherits@2.0.4: {}
+
+  is-interactive@2.0.0: {}
+
+  is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
+
+  isarray@1.0.0: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
+
+  mimic-function@5.0.1: {}
+
+  ms@2.1.3: {}
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  pako@1.0.11: {}
+
+  process-nextick-args@2.0.1: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  safe-buffer@5.1.2: {}
+
+  semver@7.8.5: {}
+
+  setimmediate@1.0.5: {}
+
+  signal-exit@4.1.0: {}
+
+  stdin-discarder@0.2.2: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
+
+  util-deprecate@1.0.2: {}

--- a/smoke/pnpm-workspace.yaml
+++ b/smoke/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: []

--- a/smoke/run.js
+++ b/smoke/run.js
@@ -1,0 +1,141 @@
+const cp = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  downloadAndUnzipVSCode,
+  resolveCliArgsFromVSCodeExecutablePath,
+  runTests
+} = require('@vscode/test-electron');
+
+const USAGE = 'usage: node run.js --expect-version <X.Y.Z> [--vsix <path>]';
+
+const EXIT_OK = 0;
+const EXIT_SMOKE_FAILED = 1;
+const EXIT_HARNESS_BROKEN = 2;
+
+/** A command line the driver cannot act on; reported with the usage text. */
+class UsageError extends Error {}
+
+/**
+ * @returns {{ expectVersion: string, vsix: string | undefined }}
+ * @throws {UsageError} on an unknown flag, a missing value or a missing --expect-version.
+ */
+function parseArgs(argv) {
+  const parsed = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag !== '--expect-version' && flag !== '--vsix') {
+      throw new UsageError(`unknown argument ${flag}`);
+    }
+    const value = argv[i + 1];
+    if (!value || value.startsWith('--')) {
+      throw new UsageError(`${flag} needs a value`);
+    }
+    parsed[flag === '--vsix' ? 'vsix' : 'expectVersion'] = value;
+    i += 1;
+  }
+  if (!parsed.expectVersion) {
+    throw new UsageError('--expect-version is required');
+  }
+  return parsed;
+}
+
+/** Creates a throwaway VS Code profile: no user data, no extensions, no result yet. */
+function createTempProfile() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lnd-smoke-'));
+  const userDataDir = path.join(root, 'user-data');
+  const extensionsDir = path.join(root, 'extensions');
+  fs.mkdirSync(userDataDir);
+  fs.mkdirSync(extensionsDir);
+  return { root, userDataDir, extensionsDir, resultFile: path.join(root, 'result.json') };
+}
+
+/** @throws {Error} when the VS Code CLI reports a non-zero status. */
+function installVsix(vscodeExecutablePath, vsix, userDataDir, extensionsDir) {
+  const [cli, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
+  const result = cp.spawnSync(
+    cli,
+    [
+      ...cliArgs,
+      '--user-data-dir',
+      userDataDir,
+      '--extensions-dir',
+      extensionsDir,
+      '--install-extension',
+      path.resolve(vsix)
+    ],
+    { stdio: 'inherit', shell: process.platform === 'win32' }
+  );
+  if (result.status !== 0) {
+    throw new Error('vsix install failed');
+  }
+}
+
+/** @returns {{ ok: boolean, failures: string[] } | undefined} undefined when unreadable. */
+function readResult(resultFile) {
+  try {
+    return JSON.parse(fs.readFileSync(resultFile, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+async function main() {
+  const { expectVersion, vsix } = parseArgs(process.argv.slice(2));
+
+  const vscodeExecutablePath = await downloadAndUnzipVSCode({
+    cachePath: path.join(__dirname, '.vscode-test')
+  });
+
+  const { root, userDataDir, extensionsDir, resultFile } = createTempProfile();
+  console.log(`smoke profile: ${root}`);
+
+  if (vsix) {
+    installVsix(vscodeExecutablePath, vsix, userDataDir, extensionsDir);
+  }
+
+  try {
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath: path.join(__dirname, 'host-extension'),
+      extensionTestsPath: path.join(__dirname, 'host-extension', 'suite', 'index.js'),
+      launchArgs: ['--user-data-dir', userDataDir, '--extensions-dir', extensionsDir],
+      extensionTestsEnv: {
+        SMOKE_EXPECT_VERSION: expectVersion,
+        SMOKE_EXTENSIONS_DIR: extensionsDir,
+        SMOKE_RESULT_FILE: resultFile
+      }
+    });
+  } catch {
+    // The result file is the source of truth; a rejection here only mirrors it.
+  }
+
+  const result = readResult(resultFile);
+  if (!result || typeof result.ok !== 'boolean') {
+    console.error('smoke harness did not produce a result');
+    return EXIT_HARNESS_BROKEN;
+  }
+  if (result.ok) {
+    console.log('smoke OK');
+    return EXIT_OK;
+  }
+  for (const failure of result.failures) {
+    console.error(`smoke FAIL: ${failure}`);
+  }
+  return EXIT_SMOKE_FAILED;
+}
+
+main().then(
+  (code) => {
+    process.exitCode = code;
+  },
+  (error) => {
+    console.error(error && error.message ? error.message : error);
+    if (error instanceof UsageError) {
+      console.error(USAGE);
+    }
+    process.exitCode = EXIT_HARNESS_BROKEN;
+  }
+);


### PR DESCRIPTION
## What

Adds a `smoke` job to `release.yml` between `build` and `release`, and gates `release` on it. The job runs on a fresh runner with only `smoke/` checked out (sparse, cone mode), downloads the VSIX artifact and:

1. **Structural check** (`smoke/inspect-vsix.js`, no VS Code): manifest present, `extension/package.json` name/publisher/version equal the tag, `main` exists and is non-empty, `out/generated/generated.js` exists, and nothing under `src/`, `out/test/`, `out/generater/`, `smoke/`, `.github/`, `node_modules/` nor any lockfile/workspace file is packaged.
2. **Negative control**: installs nothing and runs the activation assertions — the step requires exit code 1 (assertion failure), so a green smoke run can never come from leftovers or a harness that asserts nothing.
3. **Activation smoke** (`smoke/run.js` + a dummy host extension): installs the VSIX into fresh `--user-data-dir`/`--extensions-dir` temp dirs, then asserts that `ShortArrow.line-number-deco` is found, that its `extensionPath` is inside that temp extensions dir, that its version equals the tag, that `activate()` resolves with `isActive`, and that the four rainbow commands are registered.

Exit-code contract of `run.js`: 0 = all assertions passed, 1 = an assertion failed (result file is the source of truth), 2 = harness could not run.

## Also in this PR (separate commit)

`.vscodeignore` now excludes `.github/**`, `out/test/**`, `out/generater/**`, `pnpm-workspace.yaml`, `smoke/**`. They shipped in every VSIX so far; nothing at runtime imports `out/test` or `out/generater`. `vsce ls` goes from 24 to 15 files. The structural check above relies on this.

`smoke/` is its own pnpm root (`smoke/pnpm-workspace.yaml` with `packages: []`) — without it, `pnpm install` inside `smoke/` resolves to the repository workspace root and silently installs nothing.

## Verified locally (Windows, Node 26.5, pnpm 11.22, VS Code 1.134)

| case | expected | observed |
|---|---|---|
| `inspect-vsix.js <unzipped> 0.0.10` | exit 0 | `inspect OK (15 files)` |
| same with `9.9.9` | exit 1 | `inspect FAIL: version is 0.0.10, expected 9.9.9` |
| same with a planted `out/test/x.js` | exit 1 | `inspect FAIL: packaged file out/test/x.js is under out/test/` |
| `run.js --expect-version 0.0.10` (no VSIX) | exit 1 | `smoke FAIL: extension ShortArrow.line-number-deco is not installed` |
| `run.js --vsix … --expect-version 0.0.10` | exit 0 | `smoke OK` |
| `run.js --vsix … --expect-version 9.9.9` | exit 1 | `smoke FAIL: extension version is 0.0.10, expected 9.9.9` |

`actionlint` clean. Not verified: the job on an actual runner (Linux + xvfb); the first tag push is the live test.

## What this does and does not assure

It assures that the artifact attached to the release is the tagged version, contains only runtime files, and activates in a clean profile with its commands registered. It does not assure rendering behaviour, the Marketplace path, or anything about the runner image itself.
