### PR TITLE
Bump @vscode/test-electron to 3.1.0 (fixes macOS test job)

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "@types/vscode": "^1.76.0",
     "@typescript-eslint/eslint-plugin": "^5.53.0",
     "@typescript-eslint/parser": "^5.53.0",
-    "@vscode/test-electron": "^2.2.3",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.9.2",
     "eslint": "^8.34.0",
     "glob": "^8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^5.53.0
         version: 5.62.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@4.9.5)
       '@vscode/test-electron':
-        specifier: ^2.2.3
-        version: 2.5.2(supports-color@8.1.1)
+        specifier: ^3.1.0
+        version: 3.1.0(supports-color@8.1.1)
       '@vscode/vsce':
         specifier: ^3.9.2
         version: 3.9.2(supports-color@8.1.1)
@@ -320,9 +320,9 @@ packages:
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
-  '@vscode/test-electron@2.5.2':
-    resolution: {integrity: sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==}
-    engines: {node: '>=16'}
+  '@vscode/test-electron@3.1.0':
+    resolution: {integrity: sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==}
+    engines: {node: '>=22'}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
     resolution: {integrity: sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==}
@@ -2179,7 +2179,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@vscode/test-electron@2.5.2(supports-color@8.1.1)':
+  '@vscode/test-electron@3.1.0(supports-color@8.1.1)':
     dependencies:
       http-proxy-agent: 7.0.2(supports-color@8.1.1)
       https-proxy-agent: 7.0.6(supports-color@8.1.1)

--- a/smoke/package.json
+++ b/smoke/package.json
@@ -9,6 +9,6 @@
     "smoke": "node run.js"
   },
   "devDependencies": {
-    "@vscode/test-electron": "^2.5.2"
+    "@vscode/test-electron": "^3.1.0"
   }
 }

--- a/smoke/pnpm-lock.yaml
+++ b/smoke/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     devDependencies:
       '@vscode/test-electron':
-        specifier: ^2.5.2
-        version: 2.5.2
+        specifier: ^3.1.0
+        version: 3.1.0
 
 packages:
 
-  '@vscode/test-electron@2.5.2':
-    resolution: {integrity: sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==}
-    engines: {node: '>=16'}
+  '@vscode/test-electron@3.1.0':
+    resolution: {integrity: sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==}
+    engines: {node: '>=22'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -159,7 +159,7 @@ packages:
 
 snapshots:
 
-  '@vscode/test-electron@2.5.2':
+  '@vscode/test-electron@3.1.0':
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true,   /* enable all strict type-checking options */
+		"skipLibCheck": true   /* @vscode/test-electron 3.x ships types for @types/node >= 22; we pin 16.x for the VS Code 1.76 extension host */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
## Why

The first release run (`v0.0.10-beta.1`, run 32296643790) failed in `Test (macos-latest)`:

```
Test error: Error: spawn .../Visual Studio Code.app/Contents/MacOS/Electron ENOENT
```

VS Code 1.110 renamed the macOS executable from `Electron` to `Code` (microsoft/vscode#291948) and the compatibility symlink was removed on 2026-07-20 (microsoft/vscode#326502). `@vscode/test-electron` 2.x still spawns the old path; 3.1.0 (2026-07-24) resolves it via `CFBundleExecutable` (microsoft/vscode-test#350, fixes #349).

## What

- `@vscode/test-electron` `^2.2.3` → `^3.1.0` in the root and `^2.5.2` → `^3.1.0` in `smoke/` (same harness version everywhere)
- `tsconfig.json`: `skipLibCheck: true` (separate commit). test-electron 3.x ships `.d.ts` written against `@types/node` ≥ 22 (`Buffer<…>`), while this project pins `@types/node` 16.x for the VS Code 1.76 extension host. Our own sources stay under `strict`; only dependency declaration files are no longer re-checked.

## Verified locally (Windows, Node 26.5)

- `pnpm test` on a fresh profile: 48 passing, exit 0
- `pnpm exec vsce package --no-dependencies`: exit 0
- `smoke/run.js` negative control exit 1 (`not installed`), positive exit 0 (`smoke OK`)

The macOS fix itself can only be confirmed by the next tag run.