### PR TITLE
Decorate every visible range and every visible editor

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { shiftHue } from "./colors";
+import { visibleLineIndexes } from "./visibleLines";
 import {
   getColorAtCenterOfRainbow,
   getEnableRainbow,
@@ -43,9 +44,11 @@ export async function updateRelativeLineNumbers(
   const repeatingDigitsColor = getColorAtRepeatingDigits();
   const centerColorOfRainbow = getColorAtCenterOfRainbow();
   const labelWidth = document.lineCount.toString().length;
-  const endLine = document.lineCount < editor.visibleRanges[0].end.line + 2 ? document.lineCount : editor.visibleRanges[0].end.line + 2;
-  const startLine = editor.visibleRanges[0].start.line - 1 < 0 ? 0 : editor.visibleRanges[0].start.line;
-  for (let lineIndex = startLine; lineIndex < endLine; lineIndex++) {
+  const lineIndexes = visibleLineIndexes(
+    editor.visibleRanges.map((r) => ({ startLine: r.start.line, endLine: r.end.line })),
+    document.lineCount
+  );
+  for (const lineIndex of lineIndexes) {
     try {
       const lineRange = document.lineAt(lineIndex).range;
       const isCurrentLine = lineIndex === activeLineNumber;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,9 +32,13 @@ const commands = [
     updateRelativeLineNumbers(e.textEditor, decorationType);
   }),
   vscode.window.onDidChangeTextEditorVisibleRanges(event => {
-    if (event.textEditor === vscode.window.activeTextEditor) {
-      // Update decoration when visible range changes
-      updateRelativeLineNumbers(vscode.window.activeTextEditor, decorationType);
+    // Update the editor that scrolled, not just the active one: mouse-scrolling
+    // an inactive pane must refresh that pane (issue #30)
+    updateRelativeLineNumbers(event.textEditor, decorationType);
+  }),
+  vscode.window.onDidChangeVisibleTextEditors((editors) => {
+    for (const editor of editors) {
+      updateRelativeLineNumbers(editor, decorationType);
     }
   }),
   LineNumberDeco.enableRelativeLineNumbers(() => updateEnableRelativeLine(true)),
@@ -65,6 +69,9 @@ const commands = [
  */
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(...commands);
+  for (const editor of vscode.window.visibleTextEditors) {
+    updateRelativeLineNumbers(editor, decorationType);
+  }
 }
 
 /**

--- a/src/test/visibleLines.test.ts
+++ b/src/test/visibleLines.test.ts
@@ -1,0 +1,81 @@
+import * as assert from 'assert';
+import { describe, it } from 'mocha';
+import { visibleLineIndexes } from '../visibleLines';
+
+const range = (from: number, to: number) =>
+  Array.from({ length: to - from + 1 }, (_, offset) => from + offset);
+
+describe('Test visible line indexes', () => {
+  [
+    {
+      name: 'single range at top',
+      input: { ranges: [{ startLine: 0, endLine: 10 }], lineCount: 100 },
+      expected: range(0, 11),
+    },
+    {
+      name: 'single range mid-file',
+      input: { ranges: [{ startLine: 5, endLine: 10 }], lineCount: 100 },
+      expected: range(5, 11),
+    },
+    {
+      name: 'clamped at EOF',
+      input: { ranges: [{ startLine: 95, endLine: 99 }], lineCount: 100 },
+      expected: range(95, 99),
+    },
+    {
+      name: 'range ending exactly 2 before EOF',
+      input: { ranges: [{ startLine: 0, endLine: 98 }], lineCount: 100 },
+      expected: range(0, 99),
+    },
+    {
+      name: 'folded: two disjoint ranges',
+      input: {
+        ranges: [{ startLine: 0, endLine: 3 }, { startLine: 20, endLine: 30 }],
+        lineCount: 100,
+      },
+      expected: range(0, 4).concat(range(20, 31)),
+    },
+    {
+      name: 'folded: three ranges',
+      input: {
+        ranges: [
+          { startLine: 0, endLine: 0 },
+          { startLine: 10, endLine: 10 },
+          { startLine: 50, endLine: 60 },
+        ],
+        lineCount: 100,
+      },
+      expected: [0, 1].concat([10, 11]).concat(range(50, 61)),
+    },
+    {
+      name: 'adjacent after padding merge without duplicates',
+      input: {
+        ranges: [{ startLine: 0, endLine: 10 }, { startLine: 12, endLine: 20 }],
+        lineCount: 100,
+      },
+      expected: range(0, 21),
+    },
+    {
+      name: 'overlapping ranges deduplicate',
+      input: {
+        ranges: [{ startLine: 0, endLine: 10 }, { startLine: 8, endLine: 15 }],
+        lineCount: 100,
+      },
+      expected: range(0, 16),
+    },
+    {
+      name: 'no ranges',
+      input: { ranges: [], lineCount: 100 },
+      expected: [],
+    },
+    {
+      name: 'empty document',
+      input: { ranges: [{ startLine: 0, endLine: 0 }], lineCount: 0 },
+      expected: [],
+    },
+  ].forEach(({ name, input, expected }) => {
+    it(`Must become ${name} to ${JSON.stringify(expected)}`, () => {
+      assert.deepStrictEqual(visibleLineIndexes(input.ranges, input.lineCount), expected);
+    });
+  });
+});

--- a/src/test/visibleLines.test.ts
+++ b/src/test/visibleLines.test.ts
@@ -73,6 +73,11 @@ describe('Test visible line indexes', () => {
       input: { ranges: [{ startLine: 0, endLine: 0 }], lineCount: 0 },
       expected: [],
     },
+    {
+      name: 'negative start is clamped to the first line',
+      input: { ranges: [{ startLine: -2, endLine: 3 }], lineCount: 100 },
+      expected: range(0, 4),
+    },
   ].forEach(({ name, input, expected }) => {
     it(`Must become ${name} to ${JSON.stringify(expected)}`, () => {
       assert.deepStrictEqual(visibleLineIndexes(input.ranges, input.lineCount), expected);

--- a/src/visibleLines.ts
+++ b/src/visibleLines.ts
@@ -1,0 +1,23 @@
+/**
+ * Line indexes to decorate for a set of visible ranges.
+ *
+ * Each range contributes its own lines plus one padding line beyond its end
+ * (the historical single-range behaviour, kept so scrolling never shows an
+ * undecorated line at the viewport edge). Ranges may overlap; the result is
+ * ascending and duplicate-free. Folded regions produce multiple ranges, which
+ * is why every range is honoured rather than only the first (issue #32).
+ */
+export function visibleLineIndexes(
+  ranges: readonly { startLine: number; endLine: number }[],
+  lineCount: number
+): number[] {
+  const indexes = new Set<number>();
+  for (const { startLine, endLine } of ranges) {
+    const from = Math.max(0, startLine);
+    const to = Math.min(lineCount, endLine + 2);
+    for (let lineIndex = from; lineIndex < to; lineIndex++) {
+      indexes.add(lineIndex);
+    }
+  }
+  return [...indexes].sort((a, b) => a - b);
+}


### PR DESCRIPTION
Closes #32, closes #30.

## What

- **#32 (folding):** `editor.visibleRanges` splits at every folded region, and `core.ts` decorated only `visibleRanges[0]`, so every line number after the first fold disappeared. The line-index computation is extracted into a pure function, `visibleLineIndexes`, which honours every range (per-range padding kept, union, ascending, deduplicated). No DOM scanning and no extra work per fold — the fix the issue thread feared would be slow is a loop bound change.
- **#30 (inactive pane scroll):** the `onDidChangeTextEditorVisibleRanges` handler refreshed only the active editor; it now refreshes the editor that actually scrolled.
- Editors are also decorated at activation and when they become visible (`onDidChangeVisibleTextEditors`), instead of waiting for the first cursor move or scroll.

## Tests

`visibleLineIndexes` is vscode-free and unit-tested with 11 table-driven cases: the single-range rows characterize the previous behaviour (same padding and EOF clamp), the multi-range rows specify the folding fix. Red was shown before the module existed; two mutation checks (padding `+2`→`+1`, clamps removed) each fail the suite and were reverted. Full suite: 48 → 59 passing.

Not covered by tests: the event wiring in `extension.ts` (#30 / startup). VS Code offers no API to read decorations back, so those three changes are verified by review and typechecking only.