### PR TITLE
Throttle decoration updates during key repeat (#38)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,25 +16,45 @@ import {
   updateEnableRepeatingDigitsForUser,
 } from "./ui";
 import { updateRelativeLineNumbers } from "./core";
+import { throttleTrailing } from "./throttle";
 import { LineNumberDeco } from "./generated/generated";
 
 const decorationType = vscode.window.createTextEditorDecorationType({});
+
+const UPDATE_DELAY_MS = 50;
+const editorThrottles = new WeakMap<vscode.TextEditor, (editor: vscode.TextEditor) => void>();
+
+function scheduleUpdate(editor: vscode.TextEditor | undefined) {
+  if (!editor) {
+    return;
+  }
+  let throttled = editorThrottles.get(editor);
+  if (!throttled) {
+    throttled = throttleTrailing((target: vscode.TextEditor) => {
+      if (vscode.window.visibleTextEditors.includes(target)) {
+        updateRelativeLineNumbers(target, decorationType);
+      }
+    }, UPDATE_DELAY_MS);
+    editorThrottles.set(editor, throttled);
+  }
+  throttled(editor);
+}
 
 const commands = [
   vscode.workspace.onDidChangeTextDocument((e) => {
     if (e.document === vscode.window.activeTextEditor?.document) {
       // Update only if the change occurred in the currently active editor's document
-      updateRelativeLineNumbers(vscode.window.activeTextEditor, decorationType);
+      scheduleUpdate(vscode.window.activeTextEditor);
     }
   }),
   vscode.window.onDidChangeTextEditorSelection((e) => {
     // Update decoration when selection changes
-    updateRelativeLineNumbers(e.textEditor, decorationType);
+    scheduleUpdate(e.textEditor);
   }),
   vscode.window.onDidChangeTextEditorVisibleRanges(event => {
     // Update the editor that scrolled, not just the active one: mouse-scrolling
     // an inactive pane must refresh that pane (issue #30)
-    updateRelativeLineNumbers(event.textEditor, decorationType);
+    scheduleUpdate(event.textEditor);
   }),
   vscode.window.onDidChangeVisibleTextEditors((editors) => {
     for (const editor of editors) {

--- a/src/test/throttle.test.ts
+++ b/src/test/throttle.test.ts
@@ -1,0 +1,92 @@
+import * as assert from 'assert';
+import { describe, it } from 'mocha';
+import { throttleTrailing } from '../throttle';
+
+function fakeHost() {
+  let now = 0;
+  let pending: { at: number; cb: () => void } | undefined;
+  return {
+    host: {
+      now: () => now,
+      setTimeout: (cb: () => void, ms: number) => { pending = { at: now + ms, cb }; return pending; },
+      clearTimeout: () => { pending = undefined; },
+    },
+    advance(to: number) {
+      while (pending && pending.at <= to) { const p = pending; pending = undefined; now = p.at; p.cb(); }
+      now = to;
+    },
+  };
+}
+
+describe('Test leading-plus-trailing throttle', () => {
+  it('Must run the first call in a quiet period immediately', () => {
+    const { host } = fakeHost();
+    const calls: string[] = [];
+    const throttled = throttleTrailing((value: string) => { calls.push(value); }, 50, host);
+
+    throttled('a');
+
+    assert.deepStrictEqual(calls, ['a']);
+  });
+
+  it('Must defer a call inside the window to the trailing edge', () => {
+    const { host, advance } = fakeHost();
+    const calls: string[] = [];
+    const throttled = throttleTrailing((value: string) => { calls.push(value); }, 50, host);
+
+    throttled('a');
+    advance(10);
+    throttled('b');
+
+    assert.deepStrictEqual(calls, ['a']);
+
+    advance(50);
+
+    assert.deepStrictEqual(calls, ['a', 'b']);
+  });
+
+  it('Must coalesce a burst into one trailing run with the latest arguments', () => {
+    const { host, advance } = fakeHost();
+    const calls: string[] = [];
+    const throttled = throttleTrailing((value: string) => { calls.push(value); }, 50, host);
+
+    throttled('a');
+    advance(10);
+    throttled('b');
+    advance(20);
+    throttled('c');
+    advance(50);
+
+    assert.deepStrictEqual(calls, ['a', 'c']);
+  });
+
+  it('Must run immediately again once the window has elapsed', () => {
+    const { host, advance } = fakeHost();
+    const calls: string[] = [];
+    const throttled = throttleTrailing((value: string) => { calls.push(value); }, 50, host);
+
+    throttled('a');
+    advance(60);
+    throttled('b');
+
+    assert.deepStrictEqual(calls, ['a', 'b']);
+  });
+
+  it('Must re-anchor the window at the trailing run', () => {
+    const { host, advance } = fakeHost();
+    const calls: string[] = [];
+    const throttled = throttleTrailing((value: string) => { calls.push(value); }, 50, host);
+
+    throttled('a');
+    advance(10);
+    throttled('b');
+    advance(60);
+    throttled('c');
+
+    assert.deepStrictEqual(calls, ['a', 'b']);
+
+    advance(100);
+
+    assert.deepStrictEqual(calls, ['a', 'b', 'c']);
+  });
+});

--- a/src/throttle.ts
+++ b/src/throttle.ts
@@ -1,0 +1,54 @@
+export interface TimerHost {
+  now(): number;
+  setTimeout(callback: () => void, ms: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+const systemHost: TimerHost = {
+  now: () => Date.now(),
+  setTimeout: (callback, ms) => setTimeout(callback, ms),
+  clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+/**
+ * Leading-plus-trailing throttle. The first call in a quiet period runs
+ * immediately; calls arriving within delayMs of the last run are coalesced
+ * into one trailing run with the latest arguments, and the window re-anchors
+ * at every run. Keyboard auto-repeat therefore repaints at most once per
+ * delayMs while the first keypress stays instant (#38).
+ */
+export function throttleTrailing<A extends unknown[]>(
+  fn: (...args: A) => void,
+  delayMs: number,
+  host: TimerHost = systemHost
+): (...args: A) => void {
+  let lastRunAt: number | undefined;
+  let handle: unknown;
+  let latestArgs: A | undefined;
+
+  const run = (args: A) => {
+    lastRunAt = host.now();
+    fn(...args);
+  };
+
+  const fireTrailing = () => {
+    handle = undefined;
+    const args = latestArgs as A;
+    latestArgs = undefined;
+    run(args);
+  };
+
+  return (...args: A) => {
+    latestArgs = args;
+    if (handle !== undefined) {
+      return;
+    }
+    const elapsed = lastRunAt === undefined ? delayMs : host.now() - lastRunAt;
+    if (elapsed >= delayMs) {
+      latestArgs = undefined;
+      run(args);
+      return;
+    }
+    handle = host.setTimeout(fireTrailing, delayMs - elapsed);
+  };
+}


### PR DESCRIPTION
Closes #38.

## What

Selection, text and visible-range events now go through a per-editor 50 ms leading-plus-trailing throttle: the first event in a quiet period repaints immediately, and a key-repeat or scroll storm coalesces into one trailing repaint per window with the latest state. Newly visible editors and activation still paint directly.

The throttle lives in `src/throttle.ts` with an injectable clock, so its semantics are unit-tested with a fake timer (5 cases: immediate leading run, deferral inside the window, burst coalescing to the latest arguments, quiet-period reset, window re-anchoring at the trailing run). The trailing callback checks the editor is still visible before painting.

## Verified locally (Windows, Node 26.5)

- Red shown before the module existed; two mutations (bypass the window; trailing uses first args) each fail the suite and were reverted
- `pnpm test` fresh profile: 64 passing (59 before), exit 0 — the 48 integration tests are unaffected by throttling