### PR TITLE
Add a color panel with live preview to the activity bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,4 +62,5 @@ All notable changes to the "ShortArrow.line-number-deco" extension will be docum
 - Releases are built by GitHub Actions on tag push: tests on three OSes, a packaged VSIX with build provenance, and an installation smoke test (#29)
 - The VSIX no longer ships tests, the generator, or CI files
 - Package manager is pnpm instead of Yarn
+- A color panel in the activity bar previews colors live and saves them per workspace or user (#21)
 - List settings and commands in `README.md` (#20), add an `init.lua` example (#31), and trim the recommended plugin list to maintained extensions (#26)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ The `ForUser` variants write to your user settings; the others write to the curr
 | `line-number-deco.updateColorAtSequentialDigits` | LineNumberDeco: Update color of sequential digits for workspace |
 | `line-number-deco.updateColorAtSequentialDigitsForUser` | LineNumberDeco: Update color of sequential digits for user |
 
+## Color panel
+
+The LineNumberDeco entry in the activity bar opens a panel that lists every color setting with its saved value and a color picker. Dragging a picker previews that color in the open editors without saving it; Apply writes it to the workspace or to your user settings, whichever the radio at the top selects. Closing the panel discards any preview that was not applied.
+
 ## Calling commands from init.lua
 
 With [VSCode Neovim](https://marketplace.visualstudio.com/items?itemName=asvetliakov.vscode-neovim), any of the commands above can be called from Lua:

--- a/package.json
+++ b/package.json
@@ -32,6 +32,24 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "lineNumberDeco",
+          "title": "LineNumberDeco",
+          "icon": "images/icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "lineNumberDeco": [
+        {
+          "type": "webview",
+          "id": "lineNumberDeco.colors",
+          "name": "Colors"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "line-number-deco.enableRainbow",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { getPreviewColor } from "./preview";
 
 export const nameOfExtension = "LineNumberDeco";
 export const defaultCenterColorOfRainbow = "#8888ff";
@@ -17,6 +18,10 @@ export function getConfig<T>(key: string, defaultValue: T) {
 }
 
 export function getInactiveLineNumberColor() {
+  const preview = getPreviewColor("foreground");
+  if (preview !== undefined) {
+    return preview;
+  }
   const config = getConfig<string>("foreground", "");
   return config !== ""
     ? config
@@ -24,6 +29,10 @@ export function getInactiveLineNumberColor() {
 }
 
 export function getActiveLineNumberColor() {
+  const preview = getPreviewColor("activeForeground");
+  if (preview !== undefined) {
+    return preview;
+  }
   const config = getConfig<string>("activeForeground", "");
 
   return config !== ""
@@ -32,7 +41,10 @@ export function getActiveLineNumberColor() {
 }
 
 export function getColorAtCenterOfRainbow() {
-  return getConfig<string>("centerColorOfRainbow", defaultCenterColorOfRainbow);
+  return (
+    getPreviewColor("centerColorOfRainbow") ??
+    getConfig<string>("centerColorOfRainbow", defaultCenterColorOfRainbow)
+  );
 }
 
 export function getColorAtActiveRowNumber() {
@@ -52,7 +64,10 @@ export function getEnableRepeatingDigits() {
 }
 
 export function getColorAtRepeatingDigits() {
-  return getConfig<string>("foregroundColorOfRepeatingDigits", "");
+  return (
+    getPreviewColor("foregroundColorOfRepeatingDigits") ??
+    getConfig<string>("foregroundColorOfRepeatingDigits", "")
+  );
 }
 
 export function getEnableSequentialDigits() {
@@ -60,7 +75,10 @@ export function getEnableSequentialDigits() {
 }
 
 export function getColorAtSequentialDigits() {
-  return getConfig<string>("foregroundColorOfSequentialDigits", "");
+  return (
+    getPreviewColor("foregroundColorOfSequentialDigits") ??
+    getConfig<string>("foregroundColorOfSequentialDigits", "")
+  );
 }
 
 export function getEnableRelativeLine() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import {
   updateEnableSequentialDigitsForUser,
 } from "./ui";
 import { updateRelativeLineNumbers } from "./core";
+import { registerColorPanel } from "./panel";
 import { throttleTrailing } from "./throttle";
 import { LineNumberDeco } from "./generated/generated";
 
@@ -42,6 +43,13 @@ function scheduleUpdate(editor: vscode.TextEditor | undefined) {
     editorThrottles.set(editor, throttled);
   }
   throttled(editor);
+}
+
+/** Redraw every visible editor at once, bypassing the per-editor throttle. */
+function refreshVisibleEditors() {
+  for (const editor of vscode.window.visibleTextEditors) {
+    updateRelativeLineNumbers(editor, decorationType);
+  }
 }
 
 const commands = [
@@ -99,9 +107,8 @@ const commands = [
  */
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(...commands);
-  for (const editor of vscode.window.visibleTextEditors) {
-    updateRelativeLineNumbers(editor, decorationType);
-  }
+  registerColorPanel(context, refreshVisibleEditors);
+  refreshVisibleEditors();
 }
 
 /**

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -37,6 +37,17 @@ function isKnownKey(key: string) {
   return labels.some((entry) => entry.key === key);
 }
 
+let resolvedHtml: string | undefined;
+
+/**
+ * The html set at the most recent resolveWebviewView, or undefined when the
+ * view has never resolved. A test hook: the integration suite focuses the
+ * view and asserts the panel really rendered inside VS Code.
+ */
+export function getResolvedPanelHtml(): string | undefined {
+  return resolvedHtml;
+}
+
 class ColorPanelProvider implements vscode.WebviewViewProvider {
   private view: vscode.WebviewView | undefined;
 
@@ -51,6 +62,7 @@ class ColorPanelProvider implements vscode.WebviewViewProvider {
       nonce,
       webviewView.webview.cspSource
     );
+    resolvedHtml = webviewView.webview.html;
     webviewView.webview.onDidReceiveMessage((message: PanelMessage) =>
       this.handle(message)
     );

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -1,0 +1,118 @@
+import * as crypto from "crypto";
+import * as vscode from "vscode";
+import { getConfig, nameOfExtension } from "./config";
+import { PanelRow, renderPanelHtml } from "./panelHtml";
+import { clearAllPreviews, clearPreviewColor, setPreviewColor } from "./preview";
+import { updateUserConfig, updateWorkspaceConfig } from "./ui";
+
+const viewId = "lineNumberDeco.colors";
+
+const labels: { key: string; label: string }[] = [
+  { key: "centerColorOfRainbow", label: "Rainbow center" },
+  { key: "foregroundColorOfRepeatingDigits", label: "Repeating digits" },
+  { key: "foregroundColorOfSequentialDigits", label: "Sequential digits" },
+  { key: "activeForeground", label: "Active line number" },
+  { key: "foreground", label: "Inactive line number" },
+];
+
+/**
+ * The saved colors, read straight from the configuration.
+ *
+ * Previews deliberately do not show up here: the swatch is what Apply would
+ * replace, so it has to keep showing the value that is actually stored.
+ */
+function currentRows(): PanelRow[] {
+  return labels.map(({ key, label }) => ({
+    key,
+    label,
+    savedColor: getConfig<string>(key, ""),
+  }));
+}
+
+type PanelMessage =
+  | { type: "preview"; key: string; value: string }
+  | { type: "apply"; key: string; value: string; scope: string };
+
+function isKnownKey(key: string) {
+  return labels.some((entry) => entry.key === key);
+}
+
+class ColorPanelProvider implements vscode.WebviewViewProvider {
+  private view: vscode.WebviewView | undefined;
+
+  constructor(private readonly refresh: () => void) {}
+
+  resolveWebviewView(webviewView: vscode.WebviewView) {
+    this.view = webviewView;
+    webviewView.webview.options = { enableScripts: true };
+    const nonce = crypto.randomBytes(16).toString("base64");
+    webviewView.webview.html = renderPanelHtml(
+      currentRows(),
+      nonce,
+      webviewView.webview.cspSource
+    );
+    webviewView.webview.onDidReceiveMessage((message: PanelMessage) =>
+      this.handle(message)
+    );
+    webviewView.onDidChangeVisibility(() => {
+      if (!webviewView.visible) {
+        clearAllPreviews();
+        this.refresh();
+      }
+    });
+    webviewView.onDidDispose(() => {
+      this.view = undefined;
+      clearAllPreviews();
+      this.refresh();
+    });
+  }
+
+  postState() {
+    this.view?.webview.postMessage({ type: "state", rows: currentRows() });
+  }
+
+  private async handle(message: PanelMessage) {
+    if (!message || !isKnownKey(message.key)) {
+      return;
+    }
+    if (message.type === "preview") {
+      setPreviewColor(message.key, message.value);
+      this.refresh();
+      return;
+    }
+    if (message.type === "apply") {
+      clearPreviewColor(message.key);
+      if (message.scope === "user") {
+        await updateUserConfig(message.key, message.value);
+      } else {
+        await updateWorkspaceConfig(message.key, message.value);
+      }
+      this.refresh();
+      this.postState();
+    }
+  }
+}
+
+/**
+ * Register the activity bar color panel.
+ *
+ * @param context extension context the provider registration is tied to
+ * @param refresh redraws the decorations of every visible editor, so a preview
+ *   or a saved color is visible without waiting for an edit
+ */
+export function registerColorPanel(
+  context: vscode.ExtensionContext,
+  refresh: () => void
+): vscode.Disposable {
+  const provider = new ColorPanelProvider(refresh);
+  const disposables = [
+    vscode.window.registerWebviewViewProvider(viewId, provider),
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration(nameOfExtension)) {
+        provider.postState();
+      }
+    }),
+  ];
+  context.subscriptions.push(...disposables);
+  return vscode.Disposable.from(...disposables);
+}

--- a/src/panelHtml.ts
+++ b/src/panelHtml.ts
@@ -1,0 +1,118 @@
+/** One color setting as the panel shows it: the saved value beside a picker. */
+export interface PanelRow {
+  key: string;
+  label: string;
+  savedColor: string;
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+const colorPattern = /^#[0-9a-fA-F]{6}$/;
+
+/** A picker needs a well-formed value; anything else falls back to black. */
+function pickerValue(savedColor: string) {
+  return colorPattern.test(savedColor) ? savedColor : "#000000";
+}
+
+function renderRow(row: PanelRow) {
+  const key = escapeHtml(row.key);
+  const saved = escapeHtml(row.savedColor);
+  return `      <div class="row">
+        <div class="label">${escapeHtml(row.label)}</div>
+        <div class="controls">
+          <span class="swatch" data-swatch="${key}" style="background:${saved}" title="${saved}"></span>
+          <input type="color" data-key="${key}" value="${escapeHtml(pickerValue(row.savedColor))}" />
+          <button data-apply="${key}">Apply</button>
+        </div>
+      </div>`;
+}
+
+const script = `      const vscode = acquireVsCodeApi();
+      function scope() {
+        const checked = document.querySelector('input[name="scope"]:checked');
+        return checked ? checked.value : 'workspace';
+      }
+      document.querySelectorAll('input[type="color"]').forEach((input) => {
+        input.addEventListener('input', () => {
+          vscode.postMessage({ type: 'preview', key: input.dataset.key, value: input.value });
+        });
+      });
+      document.querySelectorAll('button[data-apply]').forEach((button) => {
+        button.addEventListener('click', () => {
+          const key = button.dataset.apply;
+          const input = document.querySelector('input[type="color"][data-key="' + key + '"]');
+          vscode.postMessage({ type: 'apply', key: key, value: input.value, scope: scope() });
+        });
+      });
+      window.addEventListener('message', (event) => {
+        const message = event.data;
+        if (!message || message.type !== 'state') {
+          return;
+        }
+        message.rows.forEach((row) => {
+          const swatch = document.querySelector('[data-swatch="' + row.key + '"]');
+          if (swatch) {
+            swatch.style.background = row.savedColor;
+            swatch.title = row.savedColor;
+          }
+          const input = document.querySelector('input[type="color"][data-key="' + row.key + '"]');
+          if (input && /^#[0-9a-fA-F]{6}$/.test(row.savedColor)) {
+            input.value = row.savedColor;
+          }
+        });
+      });`;
+
+const style = `      body { font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); padding: 8px; }
+      .scope { display: flex; gap: 12px; margin-bottom: 12px; }
+      .scope label { display: flex; align-items: center; gap: 4px; }
+      .row { margin-bottom: 10px; }
+      .label { margin-bottom: 4px; }
+      .controls { display: flex; align-items: center; gap: 6px; }
+      .swatch { width: 18px; height: 18px; border: 1px solid var(--vscode-panel-border); display: inline-block; }
+      input[type="color"] { width: 40px; height: 22px; padding: 0; border: none; background: none; }
+      button { color: var(--vscode-button-foreground); background: var(--vscode-button-background); border: none; padding: 2px 8px; cursor: pointer; }
+      button:hover { background: var(--vscode-button-hoverBackground); }`;
+
+/**
+ * Build the whole panel document.
+ *
+ * Every interpolated value is escaped, the policy allows nothing but the script
+ * carrying this nonce, and each row keeps its configuration key in a data
+ * attribute so the messages back to the extension need no other lookup table.
+ */
+export function renderPanelHtml(
+  rows: PanelRow[],
+  nonce: string,
+  cspSource: string
+): string {
+  const safeNonce = escapeHtml(nonce);
+  const safeCspSource = escapeHtml(cspSource);
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${safeCspSource} 'unsafe-inline'; script-src 'nonce-${safeNonce}';" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+${style}
+    </style>
+  </head>
+  <body>
+    <div class="scope">
+      <label><input type="radio" name="scope" value="workspace" checked /> Workspace</label>
+      <label><input type="radio" name="scope" value="user" /> User</label>
+    </div>
+${rows.map(renderRow).join("\n")}
+    <script nonce="${safeNonce}">
+${script}
+    </script>
+  </body>
+</html>`;
+}

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,0 +1,25 @@
+/**
+ * Colors a picker is currently proposing, keyed by configuration name.
+ *
+ * The color panel writes here while one of its pickers is being dragged, and the
+ * config getters read an override before the configuration itself, so the editors
+ * render the candidate color without anything being written to settings. Hiding
+ * the panel clears the overrides and the configured colors take over again.
+ */
+const previews = new Map<string, string>();
+
+export function setPreviewColor(key: string, value: string) {
+  previews.set(key, value);
+}
+
+export function clearPreviewColor(key: string) {
+  previews.delete(key);
+}
+
+export function clearAllPreviews() {
+  previews.clear();
+}
+
+export function getPreviewColor(key: string) {
+  return previews.get(key);
+}

--- a/src/test/panelHtml.test.ts
+++ b/src/test/panelHtml.test.ts
@@ -1,0 +1,48 @@
+import * as assert from 'assert';
+import { describe, it } from 'mocha';
+import { PanelRow, renderPanelHtml } from '../panelHtml';
+
+const rows: PanelRow[] = [
+  { key: 'centerColorOfRainbow', label: 'Rainbow center', savedColor: '#8888ff' },
+  { key: 'foreground', label: 'Inactive line number', savedColor: '' },
+];
+
+describe('Test render the color panel html', () => {
+  it('Must carry the row key on a color input', () => {
+    const html = renderPanelHtml(rows, 'n0nce', 'vscode-resource:');
+    assert.ok(/<input type="color"[^>]*data-key="centerColorOfRainbow"/.test(html));
+  });
+
+  it('Must use the nonce for the script and in the policy', () => {
+    const html = renderPanelHtml(rows, 'n0nce', 'vscode-resource:');
+    assert.ok(html.includes('<script nonce="n0nce"'));
+    assert.ok(html.includes("script-src 'nonce-n0nce'"));
+  });
+
+  it('Must deny every default source in the policy', () => {
+    const html = renderPanelHtml(rows, 'n0nce', 'vscode-resource:');
+    assert.ok(html.includes("default-src 'none'"));
+  });
+
+  it('Must show the saved color of a row', () => {
+    const html = renderPanelHtml(rows, 'n0nce', 'vscode-resource:');
+    assert.ok(html.includes('#8888ff'));
+  });
+
+  it('Must escape a saved color that looks like markup', () => {
+    const html = renderPanelHtml(
+      [{ key: 'foreground', label: 'Inactive line number', savedColor: '<img onerror=x>' }],
+      'n0nce',
+      'vscode-resource:'
+    );
+    assert.ok(!html.includes('<img'));
+  });
+
+  it('Must offer both scopes and an apply button per row', () => {
+    const html = renderPanelHtml(rows, 'n0nce', 'vscode-resource:');
+    assert.ok(html.includes('value="workspace"'));
+    assert.ok(html.includes('value="user"'));
+    assert.ok(html.includes('data-apply="centerColorOfRainbow"'));
+    assert.ok(html.includes('data-apply="foreground"'));
+  });
+});

--- a/src/test/panelView.test.ts
+++ b/src/test/panelView.test.ts
@@ -1,0 +1,30 @@
+import * as assert from 'assert';
+import { describe, it } from 'mocha';
+import * as vscode from 'vscode';
+import { getResolvedPanelHtml } from '../panel';
+
+const colorKeys = [
+  'centerColorOfRainbow',
+  'foregroundColorOfRepeatingDigits',
+  'foregroundColorOfSequentialDigits',
+  'activeForeground',
+  'foreground',
+];
+
+describe('Test color panel view', () => {
+  it('Must resolve the color panel with a picker per color when focused', async () => {
+    await vscode.commands.executeCommand('lineNumberDeco.colors.focus');
+    const deadline = Date.now() + 5000;
+    while (getResolvedPanelHtml() === undefined && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    const html = getResolvedPanelHtml();
+    assert.notStrictEqual(html, undefined, 'the color panel view never resolved');
+    for (const key of colorKeys) {
+      assert.ok(
+        (html as string).includes(`data-key="${key}"`),
+        `resolved panel html has no picker for ${key}`
+      );
+    }
+  });
+});

--- a/src/test/preview.test.ts
+++ b/src/test/preview.test.ts
@@ -1,0 +1,67 @@
+import * as assert from 'assert';
+import { describe, it } from 'mocha';
+import {
+  setPreviewColor,
+  clearPreviewColor,
+  clearAllPreviews,
+  getPreviewColor,
+} from '../preview';
+import { getColorAtCenterOfRainbow, getActiveLineNumberColor } from '../config';
+
+describe('Test preview color overrides', () => {
+  it('Must become an unset key to undefined', () => {
+    clearAllPreviews();
+    assert.strictEqual(getPreviewColor('centerColorOfRainbow'), undefined);
+  });
+
+  it('Must become a set key to the previewed value', () => {
+    clearAllPreviews();
+    setPreviewColor('centerColorOfRainbow', '#123456');
+    assert.strictEqual(getPreviewColor('centerColorOfRainbow'), '#123456');
+  });
+
+  it('Must clear one key and keep the others', () => {
+    clearAllPreviews();
+    setPreviewColor('centerColorOfRainbow', '#123456');
+    setPreviewColor('foreground', '#abcdef');
+    clearPreviewColor('centerColorOfRainbow');
+    assert.strictEqual(getPreviewColor('centerColorOfRainbow'), undefined);
+    assert.strictEqual(getPreviewColor('foreground'), '#abcdef');
+  });
+
+  it('Must clear every key at once', () => {
+    clearAllPreviews();
+    setPreviewColor('centerColorOfRainbow', '#123456');
+    setPreviewColor('foreground', '#abcdef');
+    clearAllPreviews();
+    assert.strictEqual(getPreviewColor('centerColorOfRainbow'), undefined);
+    assert.strictEqual(getPreviewColor('foreground'), undefined);
+  });
+
+  it('Must become the latest value when a key is set twice', () => {
+    clearAllPreviews();
+    setPreviewColor('centerColorOfRainbow', '#123456');
+    setPreviewColor('centerColorOfRainbow', '#654321');
+    assert.strictEqual(getPreviewColor('centerColorOfRainbow'), '#654321');
+  });
+});
+
+describe('Test config getters read previews first', () => {
+  it('Must become the previewed rainbow center, then the configured value again', () => {
+    clearAllPreviews();
+    const before = getColorAtCenterOfRainbow();
+    setPreviewColor('centerColorOfRainbow', '#0fa1b2');
+    assert.strictEqual(getColorAtCenterOfRainbow(), '#0fa1b2');
+    clearAllPreviews();
+    assert.strictEqual(getColorAtCenterOfRainbow(), before);
+  });
+
+  it('Must become the previewed active line color as a raw string', () => {
+    clearAllPreviews();
+    const before = getActiveLineNumberColor();
+    setPreviewColor('activeForeground', '#0fa1b2');
+    assert.strictEqual(getActiveLineNumberColor(), '#0fa1b2');
+    clearAllPreviews();
+    assert.deepStrictEqual(getActiveLineNumberColor(), before);
+  });
+});


### PR DESCRIPTION
Closes #21.

## What

A LineNumberDeco entry in the activity bar opens a Colors view. Each color setting shows its saved value as a swatch beside a native color picker and an Apply button; a workspace/user radio at the top picks the scope.

- Dragging a picker previews the color **live in the actual editors** without saving: the panel writes to a preview-override layer that the config getters consult first, and every visible editor repaints.
- Apply writes the color to the chosen scope through the existing update helpers and clears the preview.
- Hiding or disposing the view discards all previews, so cancel is the default.

The webview HTML comes from a pure function (`renderPanelHtml`) — every interpolation is escaped, the CSP allows only the nonce'd script — so its shape is unit-tested, including an injection case. An integration test focuses `lineNumberDeco.colors` inside the test host and asserts the resolved html carries a picker for each of the five color keys.

## Note on #35

The pane provides real color pickers, which is what #35 asked for in the input dialog; the input-box route has no picker API, so this is the closest the extension can get. Worth deciding whether #35 closes as superseded.

## Verified locally (Windows, Node 26.5)

- Red shown for each new module before it existed; HTML escaping case included
- `pnpm test` fresh profile: 102 passing (88 before), exit 0 — including the in-host resolve test
- `vsce ls`: 20 files (the three new out/*.js modules; no test/CI files)