### PR TITLE
Toggle decorations from the settings panel; monochrome activity-bar mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,5 +62,5 @@ All notable changes to the "ShortArrow.line-number-deco" extension will be docum
 - Releases are built by GitHub Actions on tag push: tests on three OSes, a packaged VSIX with build provenance, and an installation smoke test (#29)
 - The VSIX no longer ships tests, the generator, or CI files
 - Package manager is pnpm instead of Yarn
-- A color panel in the activity bar previews colors live and saves them per workspace or user (#21)
+- A settings panel in the activity bar toggles each decoration and previews colors live, saving per workspace or user (#21)
 - List settings and commands in `README.md` (#20), add an `init.lua` example (#31), and trim the recommended plugin list to maintained extensions (#26)

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ The `ForUser` variants write to your user settings; the others write to the curr
 | `line-number-deco.updateColorAtSequentialDigits` | LineNumberDeco: Update color of sequential digits for workspace |
 | `line-number-deco.updateColorAtSequentialDigitsForUser` | LineNumberDeco: Update color of sequential digits for user |
 
-## Color panel
+## Settings panel
 
-The LineNumberDeco entry in the activity bar opens a panel that lists every color setting with its saved value and a color picker. Dragging a picker previews that color in the open editors without saving it; Apply writes it to the workspace or to your user settings, whichever the radio at the top selects. Closing the panel discards any preview that was not applied.
+The LineNumberDeco entry in the activity bar opens a panel with a switch for each decoration above every color setting with its saved value and a color picker. Flipping a switch turns that decoration on or off straight away, writing to the scope the radio at the top selects. Dragging a picker previews that color in the open editors without saving it; Apply writes it to the workspace or to your user settings, whichever the radio at the top selects. Closing the panel discards any preview that was not applied.
 
 ## Calling commands from init.lua
 

--- a/images/icon-activity.svg
+++ b/images/icon-activity.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <!--
+    Monochrome activity-bar variant of images/icon.svg. VS Code uses view
+    container icons as an alpha mask and colors them from the theme, so the
+    mark is a currentColor disc with the "12" and the cursor triangle of the
+    original icon knocked out. Generic bold sans-serif stands in for the
+    original Meiryo UI, which is not available on every platform.
+  -->
+  <mask id="knockout">
+    <rect width="128" height="128" fill="black"/>
+    <circle cx="64" cy="64" r="60" fill="white"/>
+    <text x="50" y="86" font-family="sans-serif" font-size="62" font-weight="bold" text-anchor="middle" fill="black">12</text>
+    <path d="M 102 50 L 102 78 L 81 64 Z" fill="black"/>
+  </mask>
+  <rect width="128" height="128" fill="currentColor" mask="url(#knockout)"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
       "lineNumberDeco": [
         {
           "type": "webview",
-          "id": "lineNumberDeco.colors",
-          "name": "Colors"
+          "id": "lineNumberDeco.settings",
+          "name": "Settings"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         {
           "id": "lineNumberDeco",
           "title": "LineNumberDeco",
-          "icon": "images/icon.svg"
+          "icon": "images/icon-activity.svg"
         }
       ]
     },

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -1,11 +1,11 @@
 import * as crypto from "crypto";
 import * as vscode from "vscode";
 import { getConfig, nameOfExtension } from "./config";
-import { PanelRow, renderPanelHtml } from "./panelHtml";
+import { PanelRow, PanelToggle, renderPanelHtml } from "./panelHtml";
 import { clearAllPreviews, clearPreviewColor, setPreviewColor } from "./preview";
 import { updateUserConfig, updateWorkspaceConfig } from "./ui";
 
-const viewId = "lineNumberDeco.colors";
+const viewId = "lineNumberDeco.settings";
 
 const labels: { key: string; label: string }[] = [
   { key: "centerColorOfRainbow", label: "Rainbow center" },
@@ -14,6 +14,22 @@ const labels: { key: string; label: string }[] = [
   { key: "activeForeground", label: "Active line number" },
   { key: "foreground", label: "Inactive line number" },
 ];
+
+const toggles: { key: string; label: string; fallback: boolean }[] = [
+  { key: "enableRelativeLine", label: "Relative line numbers", fallback: true },
+  { key: "enableRainbow", label: "Rainbow", fallback: false },
+  { key: "enableRepeatingDigits", label: "Repeating digits", fallback: false },
+  { key: "enableSequentialDigits", label: "Sequential digits", fallback: false },
+];
+
+/** The saved state of every mode, each with its package.json default. */
+function currentToggles(): PanelToggle[] {
+  return toggles.map(({ key, label, fallback }) => ({
+    key,
+    label,
+    value: getConfig<boolean>(key, fallback),
+  }));
+}
 
 /**
  * The saved colors, read straight from the configuration.
@@ -31,10 +47,15 @@ function currentRows(): PanelRow[] {
 
 type PanelMessage =
   | { type: "preview"; key: string; value: string }
-  | { type: "apply"; key: string; value: string; scope: string };
+  | { type: "apply"; key: string; value: string; scope: string }
+  | { type: "toggle"; key: string; value: boolean; scope: string };
 
 function isKnownKey(key: string) {
   return labels.some((entry) => entry.key === key);
+}
+
+function isKnownToggle(key: string) {
+  return toggles.some((entry) => entry.key === key);
 }
 
 let resolvedHtml: string | undefined;
@@ -58,6 +79,7 @@ class ColorPanelProvider implements vscode.WebviewViewProvider {
     webviewView.webview.options = { enableScripts: true };
     const nonce = crypto.randomBytes(16).toString("base64");
     webviewView.webview.html = renderPanelHtml(
+      currentToggles(),
       currentRows(),
       nonce,
       webviewView.webview.cspSource
@@ -80,11 +102,31 @@ class ColorPanelProvider implements vscode.WebviewViewProvider {
   }
 
   postState() {
-    this.view?.webview.postMessage({ type: "state", rows: currentRows() });
+    this.view?.webview.postMessage({
+      type: "state",
+      toggles: currentToggles(),
+      rows: currentRows(),
+    });
   }
 
   private async handle(message: PanelMessage) {
-    if (!message || !isKnownKey(message.key)) {
+    if (!message) {
+      return;
+    }
+    if (message.type === "toggle") {
+      if (!isKnownToggle(message.key)) {
+        return;
+      }
+      const value = message.value === true;
+      if (message.scope === "user") {
+        await updateUserConfig(message.key, value);
+      } else {
+        await updateWorkspaceConfig(message.key, value);
+      }
+      this.refresh();
+      return;
+    }
+    if (!isKnownKey(message.key)) {
       return;
     }
     if (message.type === "preview") {

--- a/src/panelHtml.ts
+++ b/src/panelHtml.ts
@@ -5,6 +5,13 @@ export interface PanelRow {
   savedColor: string;
 }
 
+/** One boolean mode as the panel shows it: a switch carrying its saved state. */
+export interface PanelToggle {
+  key: string;
+  label: string;
+  value: boolean;
+}
+
 function escapeHtml(value: string) {
   return value
     .replace(/&/g, "&amp;")
@@ -19,6 +26,17 @@ const colorPattern = /^#[0-9a-fA-F]{6}$/;
 /** A picker needs a well-formed value; anything else falls back to black. */
 function pickerValue(savedColor: string) {
   return colorPattern.test(savedColor) ? savedColor : "#000000";
+}
+
+function renderToggle(toggle: PanelToggle) {
+  const key = escapeHtml(toggle.key);
+  return `      <label class="toggle">
+        <span class="label">${escapeHtml(toggle.label)}</span>
+        <span class="switch">
+          <input type="checkbox" data-toggle="${key}"${toggle.value ? " checked" : ""} />
+          <span class="slider"></span>
+        </span>
+      </label>`;
 }
 
 function renderRow(row: PanelRow) {
@@ -39,6 +57,16 @@ const script = `      const vscode = acquireVsCodeApi();
         const checked = document.querySelector('input[name="scope"]:checked');
         return checked ? checked.value : 'workspace';
       }
+      document.querySelectorAll('input[type="checkbox"][data-toggle]').forEach((input) => {
+        input.addEventListener('change', () => {
+          vscode.postMessage({
+            type: 'toggle',
+            key: input.dataset.toggle,
+            value: input.checked,
+            scope: scope(),
+          });
+        });
+      });
       document.querySelectorAll('input[type="color"]').forEach((input) => {
         input.addEventListener('input', () => {
           vscode.postMessage({ type: 'preview', key: input.dataset.key, value: input.value });
@@ -56,6 +84,12 @@ const script = `      const vscode = acquireVsCodeApi();
         if (!message || message.type !== 'state') {
           return;
         }
+        (message.toggles || []).forEach((toggle) => {
+          const box = document.querySelector('input[data-toggle="' + toggle.key + '"]');
+          if (box) {
+            box.checked = toggle.value;
+          }
+        });
         message.rows.forEach((row) => {
           const swatch = document.querySelector('[data-swatch="' + row.key + '"]');
           if (swatch) {
@@ -78,16 +112,28 @@ const style = `      body { font-family: var(--vscode-font-family); font-size: v
       .swatch { width: 18px; height: 18px; border: 1px solid var(--vscode-panel-border); display: inline-block; }
       input[type="color"] { width: 40px; height: 22px; padding: 0; border: none; background: none; }
       button { color: var(--vscode-button-foreground); background: var(--vscode-button-background); border: none; padding: 2px 8px; cursor: pointer; }
-      button:hover { background: var(--vscode-button-hoverBackground); }`;
+      button:hover { background: var(--vscode-button-hoverBackground); }
+      h2 { font-size: var(--vscode-font-size); text-transform: uppercase; opacity: 0.7; margin: 0 0 8px; }
+      .section { margin-bottom: 16px; }
+      .toggle { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 8px; cursor: pointer; }
+      .switch { position: relative; flex: none; width: 32px; height: 18px; }
+      .switch input { position: absolute; width: 100%; height: 100%; margin: 0; opacity: 0; cursor: pointer; }
+      .slider { position: absolute; inset: 0; border-radius: 9px; background: var(--vscode-panel-border); transition: background 0.1s; pointer-events: none; }
+      .slider::before { content: ""; position: absolute; top: 2px; left: 2px; width: 14px; height: 14px; border-radius: 50%; background: var(--vscode-button-foreground); transition: transform 0.1s; }
+      .switch input:checked + .slider { background: var(--vscode-button-background); }
+      .switch input:checked + .slider::before { transform: translateX(14px); }
+      .switch input:focus-visible + .slider { outline: 1px solid var(--vscode-focusBorder); }`;
 
 /**
  * Build the whole panel document.
  *
  * Every interpolated value is escaped, the policy allows nothing but the script
- * carrying this nonce, and each row keeps its configuration key in a data
- * attribute so the messages back to the extension need no other lookup table.
+ * carrying this nonce, and each toggle and row keeps its configuration key in a
+ * data attribute so the messages back to the extension need no other lookup
+ * table. The switches come first: they decide whether a color is drawn at all.
  */
 export function renderPanelHtml(
+  toggles: PanelToggle[],
   rows: PanelRow[],
   nonce: string,
   cspSource: string
@@ -109,7 +155,14 @@ ${style}
       <label><input type="radio" name="scope" value="workspace" checked /> Workspace</label>
       <label><input type="radio" name="scope" value="user" /> User</label>
     </div>
+    <div class="section">
+      <h2>Decorations</h2>
+${toggles.map(renderToggle).join("\n")}
+    </div>
+    <div class="section">
+      <h2>Colors</h2>
 ${rows.map(renderRow).join("\n")}
+    </div>
     <script nonce="${safeNonce}">
 ${script}
     </script>

--- a/src/test/panelHtml.test.ts
+++ b/src/test/panelHtml.test.ts
@@ -1,36 +1,44 @@
 import * as assert from 'assert';
 import { describe, it } from 'mocha';
-import { PanelRow, renderPanelHtml } from '../panelHtml';
+import { PanelRow, PanelToggle, renderPanelHtml } from '../panelHtml';
 
 const rows: PanelRow[] = [
   { key: 'centerColorOfRainbow', label: 'Rainbow center', savedColor: '#8888ff' },
   { key: 'foreground', label: 'Inactive line number', savedColor: '' },
 ];
 
+const toggles: PanelToggle[] = [
+  { key: 'enableRelativeLine', label: 'Relative line numbers', value: true },
+  { key: 'enableRainbow', label: 'Rainbow', value: false },
+  { key: 'enableRepeatingDigits', label: 'Repeating digits', value: false },
+  { key: 'enableSequentialDigits', label: 'Sequential digits', value: false },
+];
+
 describe('Test render the color panel html', () => {
   it('Must carry the row key on a color input', () => {
-    const html = renderPanelHtml(rows, 'n0nce', 'vscode-resource:');
+    const html = renderPanelHtml(toggles, rows, 'n0nce', 'vscode-resource:');
     assert.ok(/<input type="color"[^>]*data-key="centerColorOfRainbow"/.test(html));
   });
 
   it('Must use the nonce for the script and in the policy', () => {
-    const html = renderPanelHtml(rows, 'n0nce', 'vscode-resource:');
+    const html = renderPanelHtml(toggles, rows, 'n0nce', 'vscode-resource:');
     assert.ok(html.includes('<script nonce="n0nce"'));
     assert.ok(html.includes("script-src 'nonce-n0nce'"));
   });
 
   it('Must deny every default source in the policy', () => {
-    const html = renderPanelHtml(rows, 'n0nce', 'vscode-resource:');
+    const html = renderPanelHtml(toggles, rows, 'n0nce', 'vscode-resource:');
     assert.ok(html.includes("default-src 'none'"));
   });
 
   it('Must show the saved color of a row', () => {
-    const html = renderPanelHtml(rows, 'n0nce', 'vscode-resource:');
+    const html = renderPanelHtml(toggles, rows, 'n0nce', 'vscode-resource:');
     assert.ok(html.includes('#8888ff'));
   });
 
   it('Must escape a saved color that looks like markup', () => {
     const html = renderPanelHtml(
+      toggles,
       [{ key: 'foreground', label: 'Inactive line number', savedColor: '<img onerror=x>' }],
       'n0nce',
       'vscode-resource:'
@@ -39,10 +47,54 @@ describe('Test render the color panel html', () => {
   });
 
   it('Must offer both scopes and an apply button per row', () => {
-    const html = renderPanelHtml(rows, 'n0nce', 'vscode-resource:');
+    const html = renderPanelHtml(toggles, rows, 'n0nce', 'vscode-resource:');
     assert.ok(html.includes('value="workspace"'));
     assert.ok(html.includes('value="user"'));
     assert.ok(html.includes('data-apply="centerColorOfRainbow"'));
     assert.ok(html.includes('data-apply="foreground"'));
+  });
+
+  it('Must leave an off toggle unchecked', () => {
+    const html = renderPanelHtml(
+      [{ key: 'enableRainbow', label: 'Rainbow', value: false }],
+      rows,
+      'n0nce',
+      'vscode-resource:'
+    );
+    const input = /<input type="checkbox"[^>]*data-toggle="enableRainbow"[^>]*>/.exec(html);
+    assert.ok(input, 'no checkbox for enableRainbow');
+    assert.ok(!(input as RegExpExecArray)[0].includes('checked'));
+  });
+
+  it('Must check a toggle that is on', () => {
+    const html = renderPanelHtml(
+      [{ key: 'enableRainbow', label: 'Rainbow', value: true }],
+      rows,
+      'n0nce',
+      'vscode-resource:'
+    );
+    const input = /<input type="checkbox"[^>]*data-toggle="enableRainbow"[^>]*>/.exec(html);
+    assert.ok(input, 'no checkbox for enableRainbow');
+    assert.ok((input as RegExpExecArray)[0].includes('checked'));
+  });
+
+  it('Must draw every toggle above the color rows', () => {
+    const html = renderPanelHtml(toggles, rows, 'n0nce', 'vscode-resource:');
+    const firstColor = html.indexOf('data-key=');
+    for (const toggle of toggles) {
+      const at = html.indexOf(`data-toggle="${toggle.key}"`);
+      assert.ok(at >= 0, `resolved panel html has no toggle for ${toggle.key}`);
+      assert.ok(at < firstColor, `the toggle for ${toggle.key} is not above the colors`);
+    }
+  });
+
+  it('Must escape a toggle label that looks like markup', () => {
+    const html = renderPanelHtml(
+      [{ key: 'enableRainbow', label: '<b>x</b>', value: false }],
+      rows,
+      'n0nce',
+      'vscode-resource:'
+    );
+    assert.ok(!html.includes('<b>'));
   });
 });

--- a/src/test/panelView.test.ts
+++ b/src/test/panelView.test.ts
@@ -11,9 +11,16 @@ const colorKeys = [
   'foreground',
 ];
 
+const toggleKeys = [
+  'enableRelativeLine',
+  'enableRainbow',
+  'enableRepeatingDigits',
+  'enableSequentialDigits',
+];
+
 describe('Test color panel view', () => {
   it('Must resolve the color panel with a picker per color when focused', async () => {
-    await vscode.commands.executeCommand('lineNumberDeco.colors.focus');
+    await vscode.commands.executeCommand('lineNumberDeco.settings.focus');
     const deadline = Date.now() + 5000;
     while (getResolvedPanelHtml() === undefined && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -24,6 +31,12 @@ describe('Test color panel view', () => {
       assert.ok(
         (html as string).includes(`data-key="${key}"`),
         `resolved panel html has no picker for ${key}`
+      );
+    }
+    for (const key of toggleKeys) {
+      assert.ok(
+        (html as string).includes(`data-toggle="${key}"`),
+        `resolved panel html has no switch for ${key}`
       );
     }
   });


### PR DESCRIPTION
Feedback from trying v0.0.10-beta.3.

## What

- The Colors view becomes a **Settings** view (`lineNumberDeco.settings` — renamed while nothing released references the old id): a "Decorations" section with a switch per mode setting (relative line numbers, rainbow, repeating digits, sequential digits) sits above the color rows. Switches write the boolean straight to the scope the workspace/user radio picks; the existing configuration listener echoes outside edits back, so the panel and `settings.json` stay in step — the round-trip that got the good feedback.
- The activity bar gets a **monochrome mark** (`images/icon-activity.svg`). VS Code applies view-container icons as an alpha mask, which is why the colored extension icon rendered as a plain disc; the new mark knocks the "12" and the cursor triangle out of a `currentColor` disc, keeping the identity and theming itself.

## Verified locally (Windows, Node 26.5)

- 4 new unit cases for the renderer (switch markup, checked state, section order, label escaping), red shown first
- The in-host integration test now also asserts a switch per mode key in the resolved html; proven able to fail by temporarily passing an empty toggle list (1 failing), then reverted
- `pnpm test` fresh profile: 106 passing (102 before), exit 0
- The mark rasterized at activity-bar size on dark and light backgrounds reads as "12◄"